### PR TITLE
Removing outdated resources, improving api-controller responses.

### DIFF
--- a/src/GroupDocs.Comparison.WebForms.csproj
+++ b/src/GroupDocs.Comparison.WebForms.csproj
@@ -134,58 +134,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Comparison.aspx" />
-    <Content Include="Resources\common\js\es6-promise.auto.js" />
-    <Content Include="Resources\common\js\jquery.initialize.min.js" />
-    <Content Include="Resources\comparison\css\all.css" />
-    <Content Include="Resources\comparison\css\comparison.css" />
-    <Content Include="Resources\comparison\css\comparison.mobile.css" />
-    <Content Include="Resources\comparison\images\logo.png" />
-    <Content Include="Resources\comparison\js\comparison.js" />
-    <Content Include="Resources\comparison\webfonts\fa-brands-400.svg" />
-    <Content Include="Resources\comparison\webfonts\fa-regular-400.svg" />
-    <Content Include="Resources\comparison\webfonts\fa-solid-900.svg" />
     <Content Include="Global.asax" />
-    <Content Include="Resources\common\fonts\fontawesome-webfont.eot" />
-    <Content Include="Resources\common\fonts\fontawesome-webfont.ttf" />
-    <Content Include="Resources\common\fonts\fontawesome-webfont.woff" />
-    <Content Include="Resources\common\fonts\fontawesome-webfont.woff2" />
-    <Content Include="Resources\common\fonts\FontAwesome.otf" />
-    <Content Include="Resources\common\css\circle-progress.css" />
-    <Content Include="Resources\common\css\font-awesome.min.css" />
-    <Content Include="Resources\common\css\images\ui-icons_444444_256x240.png" />
-    <Content Include="Resources\common\css\images\ui-icons_555555_256x240.png" />
-    <Content Include="Resources\common\css\images\ui-icons_777620_256x240.png" />
-    <Content Include="Resources\common\css\images\ui-icons_777777_256x240.png" />
-    <Content Include="Resources\common\css\images\ui-icons_cc0000_256x240.png" />
-    <Content Include="Resources\common\css\images\ui-icons_ffffff_256x240.png" />
-    <Content Include="Resources\common\css\jquery-ui.min.css" />
-    <Content Include="Resources\common\css\swiper.min.css" />
-    <Content Include="Resources\common\fonts\fontawesome-webfont.svg" />
-    <Content Include="Resources\common\images\banner.png" />
-    <Content Include="Resources\common\js\jquery-ui.min.js" />
-    <Content Include="Resources\common\js\jquery.min.js" />
-    <Content Include="Resources\common\js\jquery.ui.touch-punch.min.js" />
-    <Content Include="Resources\common\js\swiper.min.js" />
-    <Content Include="Resources\viewer\css\viewer-dark.css" />
-    <Content Include="Resources\viewer\css\viewer-light.css" />
-    <Content Include="Resources\viewer\css\viewer.css" />
-    <Content Include="Resources\viewer\css\viewer.mobile.css" />
-    <Content Include="Resources\viewer\images\logo.png" />
-    <Content Include="Resources\viewer\js\viewer.js" />
     <Content Include="Web.config" />
     <Content Include="packages.config" />
-    <Content Include="Resources\comparison\webfonts\fa-brands-400.eot" />
-    <Content Include="Resources\comparison\webfonts\fa-brands-400.ttf" />
-    <Content Include="Resources\comparison\webfonts\fa-brands-400.woff" />
-    <Content Include="Resources\comparison\webfonts\fa-brands-400.woff2" />
-    <Content Include="Resources\comparison\webfonts\fa-regular-400.eot" />
-    <Content Include="Resources\comparison\webfonts\fa-regular-400.ttf" />
-    <Content Include="Resources\comparison\webfonts\fa-regular-400.woff" />
-    <Content Include="Resources\comparison\webfonts\fa-regular-400.woff2" />
-    <Content Include="Resources\comparison\webfonts\fa-solid-900.eot" />
-    <Content Include="Resources\comparison\webfonts\fa-solid-900.ttf" />
-    <Content Include="Resources\comparison\webfonts\fa-solid-900.woff" />
-    <Content Include="Resources\comparison\webfonts\fa-solid-900.woff2" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>
@@ -235,7 +186,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/src/Products/Comparison/Controllers/ComparisonApiController.cs
+++ b/src/Products/Comparison/Controllers/ComparisonApiController.cs
@@ -150,7 +150,7 @@ namespace GroupDocs.Comparison.WebForms.Products.Comparison.Controllers
             catch (System.Exception ex)
             {
                 // set exception message
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
             }
         }
 
@@ -183,7 +183,7 @@ namespace GroupDocs.Comparison.WebForms.Products.Comparison.Controllers
             }
             catch (Exception ex)
             {
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
             }
         }        
 
@@ -209,9 +209,9 @@ namespace GroupDocs.Comparison.WebForms.Products.Comparison.Controllers
                 // set exception message
                 if(passwordError != null)
                 {
-                    return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(passwordError, loadResultPageRequest.password));
+                    return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(passwordError, loadResultPageRequest.password));
                 } else {
-                    return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex, loadResultPageRequest.password));
+                    return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex, loadResultPageRequest.password));
                 }
                 
             }        


### PR DESCRIPTION
**Problem:**
We have outdated resources in the project that can confuse user. It would be better to response with `InternalServerError` status from the catch blocks of the api-controller.

**Solution:**
- Outdated resources were removed.
- `OK` status was replaced by `InternalServerError` in the catch blocks of the api-controller.

**Tests:**
Build&run the project, check that it works as expected.