### PR TITLE
Throw exception for corrupted files.

### DIFF
--- a/src/Products/Comparison/Service/ComparisonServiceImpl.cs
+++ b/src/Products/Comparison/Service/ComparisonServiceImpl.cs
@@ -111,6 +111,11 @@ namespace GroupDocs.Comparison.WebForms.Products.Comparison.Service
                 Dictionary<int, string> pagesContent = new Dictionary<int, string>();
                 IDocumentInfo documentInfo = comparer.Source.GetDocumentInfo();
 
+                if (documentInfo.PagesInfo == null)
+                {
+                    throw new GroupDocs.Comparison.Common.Exceptions.ComparisonException("File is corrupted.");
+                }
+
                 if (loadAllPages)
                 {
                     for (int i = 0; i < documentInfo.PageCount; i++)


### PR DESCRIPTION
Replicated changes from https://github.com/groupdocs-comparison/GroupDocs.Comparison-for-.NET-MVC/pull/33.